### PR TITLE
Improve Whisper API logging

### DIFF
--- a/adapters/whisper_adapter.py
+++ b/adapters/whisper_adapter.py
@@ -1,5 +1,6 @@
 import os
 import re
+import logging
 from typing import List
 import requests
 from dotenv import load_dotenv
@@ -19,10 +20,21 @@ def transcribe_audio_file(local_file_path: str) -> List[str]:
 
     with open(local_file_path, "rb") as audio_data:
         files = {"file": (local_file_path, audio_data)}
-        data = {"model": model}
+        data = {"model": model, "response_format": "json"}
         response = requests.post(url, headers=headers, data=data, files=files)
 
-    response_text = response.json()["text"]
+    logging.info("Whisper API status: %s", response.status_code)
+    if response.status_code != 200:
+        logging.error("Whisper API error: %s", response.text)
+    try:
+        response_text = response.json().get("text")
+    except Exception:  # JSON decoding failed
+        logging.exception("Failed to decode Whisper response: %s", response.text)
+        raise
+
+    if response_text is None:
+        logging.error("Unexpected Whisper response payload: %s", response.text)
+        raise ValueError("No transcription text returned")
 
     # Split the response text into sentences using a regular expression
     sentences = re.split("(?<=[.!?]) +", response_text)


### PR DESCRIPTION
## Summary
- improve error handling for Whisper API
- log response status and body when there's an error
- ensure JSON response by requesting `response_format=json`

## Testing
- `python -m py_compile adapters/whisper_adapter.py gpt_whisper_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_684aeac24130832daaaf807257c8348c