### PR TITLE
Improve quota error reporting

### DIFF
--- a/adapters/whisper_adapter.py
+++ b/adapters/whisper_adapter.py
@@ -26,6 +26,11 @@ def transcribe_audio_file(local_file_path: str) -> List[str]:
     logging.info("Whisper API status: %s", response.status_code)
     if response.status_code != 200:
         logging.error("Whisper API error: %s", response.text)
+        try:
+            error_msg = response.json().get("error", {}).get("message", "")
+        except Exception:
+            error_msg = response.text
+        raise RuntimeError(f"Whisper API error {response.status_code}: {error_msg}")
     try:
         response_text = response.json().get("text")
     except Exception:  # JSON decoding failed

--- a/gpt_whisper_bot.py
+++ b/gpt_whisper_bot.py
@@ -64,8 +64,19 @@ async def process_audio(update: Update, context: ContextTypes.DEFAULT_TYPE):
         file = await context.bot.get_file(file_id=audio_file.file_id)
         await file.download_to_drive(local_file_path)  #
 
+        # Inform the user that transcription is starting
+        await context.bot.send_message(
+            chat_id=update.effective_chat.id,
+            text="Starting transcription..."
+        )
+
         # Send the audio file to the OpenAI API endpoint
-        messages: List[str] = transcribe_audio_file(local_file_path)
+        try:
+            messages: List[str] = transcribe_audio_file(local_file_path)
+        except Exception as exc:
+            await context.bot.send_message(chat_id=update.effective_chat.id, text=str(exc))
+            os.remove(local_file_path)
+            return
 
         # Send each message as a separate message
         for message in messages:


### PR DESCRIPTION
## Summary
- surface OpenAI whisper errors to the user
- inform Telegram users about failures during audio processing
- notify users when transcription begins

## Testing
- `pytest -q`
- `python -m py_compile gpt_whisper_bot.py adapters/whisper_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_684aee742870832db31631c6cda35cde