### PR TITLE
Apply architecture review suggestions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/adapters/whisper_adapter.py
+++ b/adapters/whisper_adapter.py
@@ -2,14 +2,14 @@ import os
 import re
 import logging
 from typing import List
-import requests
+import httpx
 from dotenv import load_dotenv
 
 load_dotenv()
 
 
 # TODO convert to class
-def transcribe_audio_file(local_file_path: str) -> List[str]:
+async def transcribe_audio_file(local_file_path: str) -> List[str]:
     # Send the audio file to the OpenAI API endpoint
     openai_api_key = os.getenv("OPEN_AI_API_KEY")
     headers = {
@@ -18,10 +18,11 @@ def transcribe_audio_file(local_file_path: str) -> List[str]:
     url = "https://api.openai.com/v1/audio/transcriptions"
     model = "whisper-1"
 
-    with open(local_file_path, "rb") as audio_data:
-        files = {"file": (local_file_path, audio_data)}
-        data = {"model": model, "response_format": "json"}
-        response = requests.post(url, headers=headers, data=data, files=files)
+    async with httpx.AsyncClient() as client:
+        with open(local_file_path, "rb") as audio_data:
+            files = {"file": (local_file_path, audio_data)}
+            data = {"model": model, "response_format": "json"}
+            response = await client.post(url, headers=headers, data=data, files=files)
 
     logging.info("Whisper API status: %s", response.status_code)
     if response.status_code != 200:
@@ -60,3 +61,4 @@ def transcribe_audio_file(local_file_path: str) -> List[str]:
 
     # Send each message as a separate message
     return messages
+

--- a/agent.log
+++ b/agent.log
@@ -2,3 +2,4 @@ Added AGENTS.md instructions and updated .gitignore
 Added acknowledgment message before transcription
 Fixed malformed summary prompt in gpt_whisper_bot
 Added architecture review
+Implemented async http calls, shared config, added tests.

--- a/bot/bot_common.py
+++ b/bot/bot_common.py
@@ -5,20 +5,14 @@ from typing import List, Callable, Coroutine, TypeVar, Any, Dict, Optional
 import asyncio
 #from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
-from dotenv import load_dotenv
+from config import setup
 from telegram.ext import ApplicationBuilder, ContextTypes, Application
 from telegram import Update, Bot
 
 from bot.bot_lookup import bots_lookup
 from bot.bot_types import ReplyAction, Condition
 
-load_dotenv()  # Python module to load environment variables from a .env file
-
-# Configure logging (native python library)
-logging.basicConfig(
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    level=logging.INFO
-)
+setup()
 
 allowed_chat_ids: List[int] = [int(chat_id) for chat_id in os.getenv('ALLOWED_CHAT_IDS').split(',')]
 chat_ids_report: List[int] = [int(chat_id) for chat_id in os.getenv('STARTUP_CHAT_IDS_REPORT').split(',')]

--- a/config.py
+++ b/config.py
@@ -1,0 +1,12 @@
+import logging
+from dotenv import load_dotenv
+
+
+def setup(logging_level: int = logging.INFO) -> None:
+    """Load environment variables and configure logging."""
+    load_dotenv()
+    logging.basicConfig(
+        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        level=logging_level,
+    )
+

--- a/dev_bot.py
+++ b/dev_bot.py
@@ -3,7 +3,7 @@ import logging
 from typing import List, Dict, Optional
 
 import requests
-from dotenv import load_dotenv
+from config import setup
 from telegram import Update, WebAppInfo
 from telegram.ext import filters, MessageHandler, ContextTypes, CommandHandler, CallbackQueryHandler
 from adapters.notion_adapter import NotionAdapter
@@ -13,7 +13,7 @@ from bot.bot_conditions import condition_ping, condition_catch_all
 from notes_bot import action_notes
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
-load_dotenv()  # Python module to load environment variables from a .env file
+setup()
 
 # Pythonic way of creating a list, behaves like a loop
 allowed_chat_ids: List[int] = [int(chat_id) for chat_id in os.getenv('ALLOWED_CHAT_IDS').split(',')]

--- a/gpt_whisper_bot.py
+++ b/gpt_whisper_bot.py
@@ -2,7 +2,7 @@ import logging
 import os
 from typing import List
 
-from dotenv import load_dotenv
+from config import setup
 from telegram import Update
 from telegram.ext import filters, MessageHandler, ContextTypes, CommandHandler
 
@@ -13,7 +13,7 @@ from bot.bot_common import allowed_user, bot_start, run_telegram_bot, reply_buil
 from bot.bot_conditions import first_chars_lower_factory, condition_ping, \
     condition_catch_all
 
-load_dotenv()  # Python module to load environment variables from a .env file
+setup()
 
 my_open_ai = OpenAI()  # OpenAI is a custom class that works as a wrapper/adapter for OpenAI's GPT API
 
@@ -71,7 +71,7 @@ async def process_audio(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
         # Send the audio file to the OpenAI API endpoint
         try:
-            messages: List[str] = transcribe_audio_file(local_file_path)
+            messages: List[str] = await transcribe_audio_file(local_file_path)
         except Exception as exc:
             await context.bot.send_message(chat_id=update.effective_chat.id, text=str(exc))
             os.remove(local_file_path)

--- a/notes_bot.py
+++ b/notes_bot.py
@@ -1,7 +1,7 @@
 import os
 import logging
 from typing import List
-from dotenv import load_dotenv
+from config import setup
 from telegram import Update
 from telegram.ext import filters, MessageHandler, ContextTypes, CommandHandler
 from adapters.notion_adapter import NotionAdapter
@@ -9,7 +9,7 @@ from bot.bot_actions import action_ping, action_reply_factory
 from bot.bot_common import bot_start, run_telegram_bot, reply_builder
 from bot.bot_conditions import condition_ping, condition_catch_all
 
-load_dotenv()  # Python module to load environment variables from a .env file
+setup()
 
 allowed_chat_ids: List[int] = [int(chat_id) for chat_id in os.getenv('ALLOWED_CHAT_IDS').split(
     ',')]  # Pythonic way of creating a list, behaves like a loop

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ notion-client
 notion
 asyncio
 APScheduler
+httpx
+pytest

--- a/tests/test_bot_common.py
+++ b/tests/test_bot_common.py
@@ -1,0 +1,40 @@
+import asyncio
+import os
+import sys
+
+os.environ.setdefault('ALLOWED_CHAT_IDS', '1')
+os.environ.setdefault('STARTUP_CHAT_IDS_REPORT', '1')
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from bot.bot_common import reply_builder
+from bot.bot_conditions import condition_catch_all
+
+
+async def dummy_action(update, context):
+    dummy_action.called = True
+
+
+def always_true(text):
+    return True
+
+
+def test_reply_builder(monkeypatch):
+    dummy_action.called = False
+    monkeypatch.setattr('bot.bot_common.allowed_user', lambda update: True)
+    reply = reply_builder({always_true: dummy_action, condition_catch_all: dummy_action})
+
+    class DummyMessage:
+        def __init__(self):
+            self.text = "hi"
+        async def reply_text(self, text):
+            pass
+    class DummyUpdate:
+        def __init__(self):
+            self.message = DummyMessage()
+            self.effective_chat = type('chat', (), {'id': 1})
+    class DummyContext:
+        pass
+
+    asyncio.run(reply(DummyUpdate(), DummyContext()))
+    assert dummy_action.called

--- a/tests/test_whisper_adapter.py
+++ b/tests/test_whisper_adapter.py
@@ -1,0 +1,43 @@
+import asyncio
+import os
+import sys
+from types import SimpleNamespace
+import httpx
+import pytest
+
+os.environ.setdefault('OPEN_AI_API_KEY', 'test')
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from adapters.whisper_adapter import transcribe_audio_file
+
+
+class MockResponse:
+    def __init__(self, status_code=200, text="", json_data=None):
+        self.status_code = status_code
+        self.text = text
+        self._json = json_data or {}
+
+    def json(self):
+        return self._json
+
+
+class MockClient:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, *args, **kwargs):
+        return MockResponse(200, '{"text": "Hello world. Bye."}', {"text": "Hello world. Bye."})
+
+
+def test_transcribe_audio_file(tmp_path, monkeypatch):
+    audio_file = tmp_path / "test.m4a"
+    audio_file.write_bytes(b"dummy")
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **kw: MockClient())
+
+    result = asyncio.run(transcribe_audio_file(str(audio_file)))
+    assert result == ["Hello world.Bye."]


### PR DESCRIPTION
## Summary
- add a shared config module for env and logging setup
- switch Whisper adapter to use async httpx
- update bot scripts to use config and async transcriptions
- declare flake8 settings and add httpx + pytest deps
- add basic tests for reply builder and whisper adapter

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4dc47738832db5227d24f97541c8