### PR TITLE
Pin dependencies to restore docker bot stability

### DIFF
--- a/agent.log
+++ b/agent.log
@@ -2,3 +2,4 @@ Added AGENTS.md instructions and updated .gitignore
 Added acknowledgment message before transcription
 Fixed malformed summary prompt in gpt_whisper_bot
 Added architecture review
+Pinned dependency versions (including pytz) to stabilize docker bots

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
-python-telegram-bot
-openai
-requests
-python-dotenv
-notion-client
-notion
-asyncio
-APScheduler
+python-telegram-bot==20.7
+openai==0.28.1
+requests==2.31.0
+python-dotenv==1.0.1
+notion-client==2.0.0
+notion==0.0.28
+APScheduler==3.10.4
+httpx==0.25.2
+pytz==2023.3


### PR DESCRIPTION
## Summary
- pin python-telegram-bot, openai, httpx and other key dependencies to versions compatible with the existing bot code
- add pytz and align supporting packages so docker images install all required libraries consistently

## Testing
- python -m pip install -r requirements.txt
- python -m pip check

------
https://chatgpt.com/codex/tasks/task_e_68d17e7eb300832d9e6b53709d84e5f8